### PR TITLE
fix bug to export entire drawing to UIImage

### DIFF
--- a/JotUI/JotUI/JotView.m
+++ b/JotUI/JotUI/JotView.m
@@ -584,9 +584,8 @@ static const void* const kImportExportStateQueueIdentifier = &kImportExportState
 
                 // create the texture
                 // maxTextureSize
-                CGSize maxTextureSize = [UIScreen mainScreen].portraitBounds.size;
-                maxTextureSize.width *= [UIScreen mainScreen].scale;
-                maxTextureSize.height *= [UIScreen mainScreen].scale;
+                CGSize maxTextureSize = exportSize;
+      
                 JotGLTexture* canvasTexture = [[JotTextureCache sharedManager] generateTextureForContext:secondSubContext ofSize:maxTextureSize];
                 [canvasTexture bind];
 


### PR DESCRIPTION
When exporting JotView drawing to UIImage, only part of the drawing gets exported if the exportSize is big. This happens because the maxTextureSize is smaller than the JotView frame size used in our project.
Fixed it by setting maxTextureSize to exportSize instead of the main screen size. This fix is made in exportImageOnComplete in JotView.m