### PR TITLE
Allow JotView to run at 60 FPS and above

### DIFF
--- a/JotUI/JotUI/JotGLLayerBackedFrameBuffer.h
+++ b/JotUI/JotUI/JotGLLayerBackedFrameBuffer.h
@@ -15,7 +15,6 @@
 @interface JotGLLayerBackedFrameBuffer : AbstractJotGLFrameBuffer <DeleteAssets>
 
 @property(readonly) CGSize initialViewport;
-@property(assign) BOOL shouldslow;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/JotUI/JotUI/JotGLLayerBackedFrameBuffer.m
+++ b/JotUI/JotUI/JotGLLayerBackedFrameBuffer.m
@@ -27,18 +27,12 @@
     // YES if we need to present our renderbuffer on the
     // next display link
     BOOL needsPresentRenderBuffer;
-    // YES if we should limit to 30fps, NO otherwise
-    BOOL shouldslow;
-    // helper var to toggle between frames for 30fps limit
-    BOOL slowtoggle;
-
 
     // TODO: pull this into somewhere else
     GLSize backingSize;
 }
 
 @synthesize initialViewport;
-@synthesize shouldslow;
 
 - (id)initForLayer:(CALayer<EAGLDrawable>*)_layer {
     if (self = [super init]) {
@@ -87,7 +81,7 @@
 
 - (void)presentRenderBufferInContext:(JotGLContext*)context {
     [context runBlock:^{
-        if (needsPresentRenderBuffer && (!shouldslow || slowtoggle)) {
+        if (needsPresentRenderBuffer) {
             [self bind];
             //        NSLog(@"presenting");
             [context assertCurrentBoundFramebufferIs:framebufferID andRenderBufferIs:viewRenderbuffer];
@@ -98,7 +92,6 @@
             needsPresentRenderBuffer = NO;
             [self unbind];
         }
-        slowtoggle = !slowtoggle;
         if ([context needsFlush]) {
             [context flush];
         }

--- a/JotUI/JotUI/JotView.h
+++ b/JotUI/JotUI/JotView.h
@@ -82,6 +82,7 @@
 
 - (void)slowDownFPS;
 - (void)speedUpFPS;
+- (void)setPreferredFPS:(NSInteger)preferredFramesPerSecond;
 
 - (NSInteger)maxCurrentStrokeByteSize;
 - (void)addElements:(NSArray*)elements withTexture:(JotBrushTexture*)texture;

--- a/JotUI/JotUI/JotView.m
+++ b/JotUI/JotUI/JotView.m
@@ -142,7 +142,11 @@ static JotGLContext* mainThreadContext;
     self.maxStrokeSize = 512 * 1024;
 
     displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(displayLinkPresentRenderBuffer:)];
-    displayLink.frameInterval = 2;
+    if ([displayLink respondsToSelector:@selector(preferredFramesPerSecond)]) {
+        displayLink.preferredFramesPerSecond = 30;
+    } else {
+        displayLink.frameInterval = 2;
+    }
     [displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
 
     initialFrameSize = self.bounds.size;
@@ -1060,6 +1064,11 @@ static const void* const kImportExportStateQueueIdentifier = &kImportExportState
  * cut our framerate by half
  */
 - (void)slowDownFPS {
+    if ([displayLink respondsToSelector:@selector(preferredFramesPerSecond)]) {
+        displayLink.preferredFramesPerSecond = 30;
+    } else {
+        displayLink.frameInterval = 2;
+    }
     viewFramebuffer.shouldslow = YES;
 }
 /**
@@ -1067,6 +1076,15 @@ static const void* const kImportExportStateQueueIdentifier = &kImportExportState
  * the full hardware limit
  */
 - (void)speedUpFPS {
+    if ([displayLink respondsToSelector:@selector(preferredFramesPerSecond)]) {
+        NSInteger maxFPS = 60;
+        if ([[UIScreen mainScreen] respondsToSelector:@selector(maximumFramesPerSecond)]){
+            maxFPS = [[UIScreen mainScreen] maximumFramesPerSecond];
+        }
+        displayLink.preferredFramesPerSecond = maxFPS;
+    } else {
+        displayLink.frameInterval = 1;
+    }
     viewFramebuffer.shouldslow = NO;
 }
 


### PR DESCRIPTION
The `JotView` class is currently hard-coded to [skip every other frame](https://github.com/adamwulf/JotUI/blob/4580df6b69cc19c51b3025c40cdceb2187dc1fb3/JotUI/JotUI/JotView.m#L145), meaning that it refreshes at 30 FPS on most devices. The `JotGLLayerBackedFrameBuffer` class also contains an additional set of logic to skip every other frame *again* by using `shouldslow` – if you call `jotview.slowDownFPS()`, this effectively lowers the refresh rate to 15 FPS.

I assume those limits was originally added because some devices weren't powerful enough to drive more than 30 FPS, but on newer devices with more horsepower, it'd be great to run at 60 FPS (or even 120 FPS on the new iPad Pro).

This PR maintains the JotUI library's existing default refresh rate of 30 FPS, but updates `jotView.speedUpFPS()` to properly support the device's maximum refresh rate. It also adds a `jotView.setPreferredFPS()` method in case a developer wants more manual control over the refresh rate.

If it makes sense to the library maintainer, I would love to update the library's default refresh rate to 60 FPS to improve the smoothness of drawing, but I haven't tested that with older devices and I don't know if it would have any significant negative effects.