### PR TITLE
Add `undoLimit` property to customize how much undo history is stored

### DIFF
--- a/JotUI/JotUI/JotViewState.h
+++ b/JotUI/JotUI/JotViewState.h
@@ -22,6 +22,7 @@
 
 // ability to cancel strokes
 @property(nonatomic, weak) NSObject<JotStrokeDelegate>* delegate;
+@property(nonatomic, assign) int undoLimit;
 
 // backing textures
 @property(nonatomic, strong) JotGLTexture* backgroundTexture;

--- a/JotUI/JotUI/JotViewState.m
+++ b/JotUI/JotUI/JotViewState.m
@@ -52,6 +52,7 @@
 }
 
 @synthesize delegate;
+@synthesize undoLimit;
 @synthesize backgroundTexture;
 @synthesize backgroundFramebuffer;
 @synthesize currentStroke;
@@ -65,6 +66,7 @@
         stackOfStrokes = [NSMutableArray array];
         stackOfUndoneStrokes = [NSMutableArray array];
         strokesBeingWrittenToBackingTexture = [NSMutableArray array];
+        undoLimit = kJotDefaultUndoLimit;
     }
     return self;
 }
@@ -237,8 +239,8 @@ static JotGLContext* backgroundLoadStrokesThreadContext = nil;
 
 - (void)tick {
     @synchronized(self) {
-        if ([stackOfStrokes count] > kJotDefaultUndoLimit) {
-            while ([stackOfStrokes count] > kJotDefaultUndoLimit) {
+        if ([stackOfStrokes count] > undoLimit) {
+            while ([stackOfStrokes count] > undoLimit) {
                 [strokesBeingWrittenToBackingTexture addObject:[stackOfStrokes objectAtIndex:0]];
                 [stackOfStrokes removeObjectAtIndex:0];
             }
@@ -275,12 +277,12 @@ static JotGLContext* backgroundLoadStrokesThreadContext = nil;
     @synchronized(self) {
         if ([strokesBeingWrittenToBackingTexture count] ||
             currentStroke ||
-            [stackOfStrokes count] > kJotDefaultUndoLimit) {
+            [stackOfStrokes count] > undoLimit) {
             if (currentStroke) {
                 // can't save, currently drawing
             } else if ([strokesBeingWrittenToBackingTexture count]) {
                 // can't save, writing to texture
-            } else if ([stackOfStrokes count] > kJotDefaultUndoLimit) {
+            } else if ([stackOfStrokes count] > undoLimit) {
                 // can't save, more strokes than our undo limit, waiting until they're written to texture
             }
             return NO;

--- a/JotUI/JotUI/JotViewStateProxy.h
+++ b/JotUI/JotUI/JotViewStateProxy.h
@@ -27,6 +27,7 @@
 @property(nonatomic, strong) JotStroke* currentStroke;
 @property(nonatomic, readonly) int fullByteSize;
 @property(nonatomic, assign) BOOL isForgetful;
+@property(nonatomic, assign) int undoLimit;
 
 - (id)initWithDelegate:(NSObject<JotViewStateProxyDelegate>*)delegate;
 

--- a/JotUI/JotUI/JotViewStateProxy.m
+++ b/JotUI/JotUI/JotViewStateProxy.m
@@ -284,6 +284,13 @@ static dispatch_queue_t loadUnloadStateQueue;
     [self.jotViewState addUndoLevelAndContinueStroke];
 }
 
+- (int)undoLimit {
+    return [jotViewState undoLimit];
+}
+- (void)setUndoLimit:(int)undoLimit {
+    jotViewState.undoLimit = undoLimit;
+}
+
 #pragma mark - Dealloc
 
 - (void)dealloc {


### PR DESCRIPTION
This PR adds a `undoLimit` property to allow apps to customize how many undo steps are kept in memory. For example, if you wanted to change the `undoLimit` in the provided example app, you could simply add the following on [line 41 of ViewController.m](https://github.com/rofreg/JotUI/blob/8e07988425a903f9c7e59b652da71f1c44b481e6/jotuiexample/jotuiexample/ViewController.m#L41):

```
paperState.undoLimit = 20;
```